### PR TITLE
Bump pom.xml to prepare for dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>open-dis</artifactId>
     <packaging>jar</packaging>
     <name>Open-DIS</name>
-    <version>4.13-SNAPSHOT</version>
+    <version>4.16-SNAPSHOT</version>
     <description>An open source implementation of the Distributed Interactive Simulation (DIS) IEEE-1278 protocol</description>
     <url>http://open-dis.sourceforge.net</url>
     <licenses>


### PR DESCRIPTION
After we do a release we should bump the Maven pom.xml to prepare for the next development period. This is a Maven'y thing so that no two commits produce the same "release" artifact.

P.S. As part of the `4.15` release we should have updated the pom.xml `version` to drop the `-SNAPSHOT` part from the string. We can get that sorted out before we cut the `4.16` release though. There's a few other Maven'y things I plan to fix before related to the github move and repository restructure anyways.