### PR TITLE
Add Maven Central badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 Open-DIS git repository for the Java implementation
 
 [![Build Status](https://travis-ci.org/open-dis/open-dis-java.svg?branch=master)](https://travis-ci.org/open-dis/open-dis-java)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/edu.nps.moves/open-dis/badge.svg)](https://maven-badges.herokuapp.com/maven-central/edu.nps.moves/open-dis)


### PR DESCRIPTION
This badge will be a reminder to open-dis users (and ourselves) what the latest version that's been deployed and available in Maven Central is.