### PR TITLE
Add javadoc badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ source code.
 
 [![Build Status](https://travis-ci.org/open-dis/open-dis-java.svg?branch=master)](https://travis-ci.org/open-dis/open-dis-java)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/edu.nps.moves/open-dis/badge.svg)](https://maven-badges.herokuapp.com/maven-central/edu.nps.moves/open-dis)
+[![Javadocs](http://www.javadoc.io/badge/edu.nps.moves/open-dis.svg)](http://www.javadoc.io/doc/edu.nps.moves/open-dis)


### PR DESCRIPTION
This is so magic. It grabs the latest javadoc.jar that we've published to Maven Central, unpacks it on demand, and hosts it for easy browsing.