### PR TITLE
Fix marking test

### DIFF
--- a/src/main/java/edu/nps/moves/dis/Marking.java
+++ b/src/main/java/edu/nps/moves/dis/Marking.java
@@ -68,6 +68,9 @@ public void setCharacters(byte[] pCharacters)
  }
 }
 
+public byte[] getCharacters()
+{ return characters; }
+
 /**
  * An added conveniece method (added by patch): accepts a string, and either
  * truncates or zero-fills it to fit into the 11-byte character marking field.

--- a/src/test/java/edu/nps/moves/dis/MarkingTest.java
+++ b/src/test/java/edu/nps/moves/dis/MarkingTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.*;
  */
 public class MarkingTest
 {
+    private static final int MARKING_STRING_LENGTH = 11;
+    
     public void Marking()
     {
 
@@ -29,7 +31,7 @@ public class MarkingTest
         final String s = new String("This is a marking that is much, much too loong");
         marking.setCharacters(s.getBytes());
         byte[] buff = marking.getCharacters();
-        assertEquals(buff.length, s.length());
+        assertEquals(buff.length, MARKING_STRING_LENGTH);
     }
 
     @Test
@@ -40,7 +42,7 @@ public class MarkingTest
         final String s = new String("short");
         marking.setCharacters(s.getBytes());
         byte[] buff = marking.getCharacters();
-        assertEquals(buff.length, s.length());
+        assertEquals(buff.length, MARKING_STRING_LENGTH);
     }
 
     @Before


### PR DESCRIPTION
Broke in f3a1691e90fb1dcad28d04070b98f9036bf45d46

Returned length is always 11 now. A zero padded string.

And I think it makes sense to keep Marking#getCharacters to avoid breakage
of users of the library.