### PR TITLE
Add java 9+ support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>edu.nps.moves.open-dis</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.3</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>edu.nps.moves.open-dis</Automatic-Module-Name>
+                            <Automatic-Module-Name>edu.nps.moves.dis</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
This works around an issue with java 9+ automatic module naming in particular when using open-dis artifacts from jitpack. It doesn't seem to like the sha1 in the name. Unlike creating a module-info.java file, this change retains compatibility with Java 6-8.