### PR TITLE
Removed DIS 6 & 7 length fields, replacing uses with dynamic getMarshalledSize()

### DIFF
--- a/src/main/java/edu/nps/moves/dis/Pdu.java
+++ b/src/main/java/edu/nps/moves/dis/Pdu.java
@@ -33,9 +33,6 @@ public class Pdu extends Object implements Serializable
    /** Timestamp value */
    protected long  timestamp;
 
-   /** Length, in bytes, of the PDU. Changed name from length to avoid use of Hibernate QL reserved word */
-   protected int  pduLength;
-
    /** zero-filled array of padding */
    protected short  padding = (short)0;
 
@@ -116,12 +113,16 @@ public long getTimestamp()
 { return timestamp; 
 }
 
+/** @deprecated PDU length is determined by the PDU type and content and cannot be set directly */
+@Deprecated
 public void setPduLength(int pPduLength)
-{ pduLength = pPduLength;
+{
 }
 
+/** @deprecated Use {@link #getMarshalledSize()} */
+@Deprecated
 public int getPduLength()
-{ return pduLength; 
+{ return getMarshalledSize(); 
 }
 
 public void setPadding(short pPadding)
@@ -182,7 +183,7 @@ public void unmarshal(DataInputStream dis)
         byte[] header = new byte[12];
         dis.mark(header.length);
         dis.read(header, 0, header.length);
-        pduLength = (int) ByteBuffer.wrap(header).getShort(8);
+        int pduLength = ByteBuffer.wrap(header).getShort(8);
         dis.reset();
         
         // Now allocate enough space for full pdu
@@ -228,7 +229,7 @@ public void unmarshal(java.nio.ByteBuffer buff)
        pduType = (short)(toUnsignedInt(buff.get()));
        protocolFamily = (short)(toUnsignedInt(buff.get()));
        timestamp = buff.getInt();
-       pduLength = toUnsignedInt(buff.getShort());
+       int pduLength = toUnsignedInt(buff.getShort());
        padding = buff.getShort();
  } // end of unmarshal method 
 
@@ -369,7 +370,7 @@ public byte[] marshal()
      if( ! (pduType == rhs.pduType)) ivarsEqual = false;
      if( ! (protocolFamily == rhs.protocolFamily)) ivarsEqual = false;
      if( ! (timestamp == rhs.timestamp)) ivarsEqual = false;
-     if( ! (pduLength == rhs.pduLength)) ivarsEqual = false;
+     if( ! (getMarshalledSize() == rhs.getMarshalledSize())) ivarsEqual = false;
      if( ! (padding == rhs.padding)) ivarsEqual = false;
 
     return ivarsEqual;

--- a/src/main/java/edu/nps/moves/dis/Pdu.java
+++ b/src/main/java/edu/nps/moves/dis/Pdu.java
@@ -184,6 +184,7 @@ public void unmarshal(DataInputStream dis)
         dis.mark(header.length);
         dis.read(header, 0, header.length);
         int pduLength = ByteBuffer.wrap(header).getShort(8);
+        setPduLength(pduLength);
         dis.reset();
         
         // Now allocate enough space for full pdu
@@ -230,6 +231,7 @@ public void unmarshal(java.nio.ByteBuffer buff)
        protocolFamily = (short)(toUnsignedInt(buff.get()));
        timestamp = buff.getInt();
        int pduLength = toUnsignedInt(buff.getShort());
+       setPduLength(pduLength);
        padding = buff.getShort();
  } // end of unmarshal method 
 

--- a/src/main/java/edu/nps/moves/dis7/PduSuperclass.java
+++ b/src/main/java/edu/nps/moves/dis7/PduSuperclass.java
@@ -28,9 +28,6 @@ public class PduSuperclass extends Object implements Serializable
    /** Timestamp value */
    protected long  timestamp;
 
-   /** Length, in bytes, of the PDU */
-   protected int  length;
-
 
 /** Constructor */
  public PduSuperclass()
@@ -92,12 +89,16 @@ public long getTimestamp()
 { return timestamp; 
 }
 
+/** @deprecated PDU length is determined by the PDU type and content and cannot be set directly */
+@Deprecated
 public void setLength(int pLength)
-{ length = pLength;
+{
 }
 
+/** @deprecated Use {@link #getMarshalledSize()} */
+@Deprecated
 public int getLength()
-{ return length; 
+{ return getMarshalledSize(); 
 }
 
 
@@ -110,7 +111,7 @@ public void marshal(DataOutputStream dos)
        dos.writeByte( (byte)pduType);
        dos.writeByte( (byte)protocolFamily);
        dos.writeInt( (int)timestamp);
-       dos.writeShort( (short)length);
+       dos.writeShort( (short)getMarshalledSize());
     } // end try 
     catch(Exception e)
     { 
@@ -126,7 +127,7 @@ public void unmarshal(DataInputStream dis)
        pduType = (short)dis.readUnsignedByte();
        protocolFamily = (short)dis.readUnsignedByte();
        timestamp = dis.readInt();
-       length = (int)dis.readUnsignedShort();
+       int length = (int)dis.readUnsignedShort();
     } // end try 
    catch(Exception e)
     { 
@@ -150,7 +151,7 @@ public void marshal(java.nio.ByteBuffer buff)
        buff.put( (byte)pduType);
        buff.put( (byte)protocolFamily);
        buff.putInt( (int)timestamp);
-       buff.putShort( (short)length);
+       buff.putShort( (short)getMarshalledSize());
     } // end of marshal method
 
 /**
@@ -167,7 +168,7 @@ public void unmarshal(java.nio.ByteBuffer buff)
        pduType = (short)(buff.get() & 0xFF);
        protocolFamily = (short)(buff.get() & 0xFF);
        timestamp = buff.getInt();
-       length = (int)(buff.getShort() & 0xFFFF);
+       int length = (int)(buff.getShort() & 0xFFFF);
  } // end of unmarshal method 
 
 
@@ -212,7 +213,7 @@ public void unmarshal(java.nio.ByteBuffer buff)
      if( ! (pduType == rhs.pduType)) ivarsEqual = false;
      if( ! (protocolFamily == rhs.protocolFamily)) ivarsEqual = false;
      if( ! (timestamp == rhs.timestamp)) ivarsEqual = false;
-     if( ! (length == rhs.length)) ivarsEqual = false;
+     if( ! (getMarshalledSize() == rhs.getMarshalledSize())) ivarsEqual = false;
 
     return ivarsEqual;
  }

--- a/src/main/java/edu/nps/moves/disutil/ExperimentalPdu.java
+++ b/src/main/java/edu/nps/moves/disutil/ExperimentalPdu.java
@@ -47,6 +47,12 @@ public class ExperimentalPdu extends Pdu {
     }
 
     @Override
+	public void setPduLength(int pPduLength) {
+		super.setPduLength(pPduLength);
+		body = new byte[pPduLength = super.getMarshalledSize()];
+	}
+
+	@Override
 	public int getMarshalledSize() {
 		return super.getMarshalledSize() + body.length;
 	}
@@ -62,7 +68,8 @@ public class ExperimentalPdu extends Pdu {
     public void unmarshal(java.nio.ByteBuffer buff) {
         super.unmarshal(buff);
 
-        body = new byte[this.getPduLength() - 12]; // 12 is size of the pdu header.
+		// abutler - The body is now initialized in the setPduLength() call
+		// body = new byte[this.getPduLength() - 12]; // 12 is size of the pdu header.
         buff.get(body);
     }
 }

--- a/src/main/java/edu/nps/moves/disutil/ExperimentalPdu.java
+++ b/src/main/java/edu/nps/moves/disutil/ExperimentalPdu.java
@@ -49,7 +49,7 @@ public class ExperimentalPdu extends Pdu {
     @Override
 	public void setPduLength(int pPduLength) {
 		super.setPduLength(pPduLength);
-		body = new byte[pPduLength = super.getMarshalledSize()];
+		body = new byte[pPduLength - super.getMarshalledSize()];
 	}
 
 	@Override

--- a/src/main/java/edu/nps/moves/disutil/ExperimentalPdu.java
+++ b/src/main/java/edu/nps/moves/disutil/ExperimentalPdu.java
@@ -47,6 +47,11 @@ public class ExperimentalPdu extends Pdu {
     }
 
     @Override
+	public int getMarshalledSize() {
+		return super.getMarshalledSize() + body.length;
+	}
+
+	@Override
     public void marshal(java.nio.ByteBuffer buff) {
         super.marshal(buff);
 


### PR DESCRIPTION
As noted in the commits, the length fields for both PDU superclasses are removed, the getter and setter deprecated, and uses replaced correctly.

I tested this locally using EntityState and Acknowledge PDU types for DIS 6 and 7 with no errors.