### PR TITLE
avoid null pointer exception 

### DIFF
--- a/src/main/java/edu/nps/moves/dis/ArticulationParameter.java
+++ b/src/main/java/edu/nps/moves/dis/ArticulationParameter.java
@@ -26,7 +26,7 @@ public class ArticulationParameter extends Object implements Serializable {
 
     protected double parameterValue;
 
-    protected EntityType entityType;
+    protected EntityType entityType = new EntityType();
 
     protected final int ARTICULATED_PART = 0;
 


### PR DESCRIPTION
It is possible to get a null pointer exception, when un-marshalling  an Attached Part Entity Type, as it is not intialized in the setup of ArticulationParameter.java class
