### PR TITLE
Dis7 electronic emitter fixes

### DIFF
--- a/src/main/java/edu/nps/moves/dis7/ElectronicEmissionSystemData.java
+++ b/src/main/java/edu/nps/moves/dis7/ElectronicEmissionSystemData.java
@@ -1,0 +1,275 @@
+package edu.nps.moves.dis7;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * Data about one electronic system
+ *
+ * Copyright (c) 2008-2016, MOVES Institute, Naval Postgraduate School. All
+ * rights reserved. This work is licensed under the BSD open source license,
+ * available at https://www.movesinstitute.org/licenses/bsd.html
+ *
+ * @author DMcG
+ */
+public class ElectronicEmissionSystemData extends Object implements Serializable {
+
+    /**
+     * This field shall specify the length of this emitter system�s data
+     * (including beam data and its track/jam information) in 32-bit words. The
+     * length shall include the System Data Length field.
+     */
+    protected short systemDataLength;
+
+    /**
+     * This field shall specify the number of beams being described in the
+     * current PDU for the system being described.
+     */
+    protected short numberOfBeams;
+
+    /**
+     * padding.
+     */
+    protected int emissionsPadding2 = (int) 0;
+
+    /**
+     * This field shall specify information about a particular emitter system
+     */
+    protected EmitterSystem emitterSystem = new EmitterSystem();
+
+    /**
+     * Location with respect to the entity
+     */
+    protected Vector3Float location = new Vector3Float();
+
+    /**
+     * variable length variablelist of beam data records
+     */
+    protected List< ElectronicEmissisionBeamData> beamDataRecords = new ArrayList< ElectronicEmissisionBeamData>();
+
+    /**
+     * Constructor
+     */
+    public ElectronicEmissionSystemData() {
+    }
+
+    public int getMarshalledSize() {
+        int marshalSize = 0;
+
+        marshalSize = marshalSize + 1;  // systemDataLength
+        marshalSize = marshalSize + 1;  // numberOfBeams
+        marshalSize = marshalSize + 2;  // emissionsPadding2
+        marshalSize = marshalSize + emitterSystem.getMarshalledSize();  // emitterSystem
+        marshalSize = marshalSize + location.getMarshalledSize();  // location
+        for (int idx = 0; idx < beamDataRecords.size(); idx++) {
+            ElectronicEmissisionBeamData listElement = beamDataRecords.get(idx);
+            marshalSize = marshalSize + listElement.getMarshalledSize();
+        }
+
+        return marshalSize;
+    }
+
+    public short getSystemDataLength() {
+        return systemDataLength;
+    }
+
+    private short calculateSystemDataLength() {
+        //systemdata length = 5 + 13*beamCount + 2*track/jamTargets * nr of targets
+        short size = 5;// Sys Data Length+nr of beams + padding + emitter system record + location fields in 32 bit words
+        for (int i = 0; i < beamDataRecords.size(); i++) {
+            ElectronicEmissisionBeamData bd = beamDataRecords.get(i);
+            size += bd.calculateBeamDataLength();
+        }
+        return size;
+    }
+
+    public short getNumberOfBeams() {
+        return (short) beamDataRecords.size();
+    }
+
+    /**
+     * Note that setting this value will not change the marshalled value. The
+     * list whose length this describes is used for that purpose. The
+     * getnumberOfBeams method will also be based on the actual list length
+     * rather than this value. The method is simply here for java bean
+     * completeness.
+     */
+    public void setNumberOfBeams(short pNumberOfBeams) {
+        numberOfBeams = pNumberOfBeams;
+    }
+
+    public void setEmissionsPadding2(int pEmissionsPadding2) {
+        emissionsPadding2 = pEmissionsPadding2;
+    }
+
+    public int getEmissionsPadding2() {
+        return emissionsPadding2;
+    }
+
+    public void setEmitterSystem(EmitterSystem pEmitterSystem) {
+        emitterSystem = pEmitterSystem;
+    }
+
+    public EmitterSystem getEmitterSystem() {
+        return emitterSystem;
+    }
+
+    public void setLocation(Vector3Float pLocation) {
+        location = pLocation;
+    }
+
+    public Vector3Float getLocation() {
+        return location;
+    }
+
+    public void setBeamDataRecords(List<ElectronicEmissisionBeamData> pBeamDataRecords) {
+        beamDataRecords = pBeamDataRecords;
+    }
+
+    public List<ElectronicEmissisionBeamData> getBeamDataRecords() {
+        return beamDataRecords;
+    }
+
+    public void marshal(DataOutputStream dos) {
+        try {
+            dos.writeByte((byte) calculateSystemDataLength());
+            dos.writeByte((byte) beamDataRecords.size());
+            dos.writeShort((short) emissionsPadding2);
+            emitterSystem.marshal(dos);
+            location.marshal(dos);
+
+            for (int idx = 0; idx < beamDataRecords.size(); idx++) {
+                ElectronicEmissisionBeamData aElectronicEmissionBeamData = (ElectronicEmissisionBeamData) beamDataRecords.get(idx);
+                aElectronicEmissionBeamData.marshal(dos);
+            } // end of list marshalling
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+    }   
+    
+    /**
+     * Packs a Pdu into the ByteBuffer.
+     *
+     * @throws java.nio.BufferOverflowException if buff is too small
+     * @throws java.nio.ReadOnlyBufferException if buff is read only
+     * @see java.nio.ByteBuffer
+     * @param buff The ByteBuffer at the position to begin writing
+     * @since ??
+     */
+    public void marshal(java.nio.ByteBuffer buff) {
+        buff.put((byte) calculateSystemDataLength());
+        buff.put((byte) beamDataRecords.size());
+        buff.putShort((short) emissionsPadding2);
+        emitterSystem.marshal(buff);
+        location.marshal(buff);
+
+        for (int idx = 0; idx < beamDataRecords.size(); idx++) {
+            ElectronicEmissisionBeamData aElectronicEmissionBeamData = (ElectronicEmissisionBeamData) beamDataRecords.get(idx);
+            aElectronicEmissionBeamData.marshal(buff);
+        } // end of list marshalling
+
+    } // end of marshal method
+
+    public void unmarshal(DataInputStream dis) {
+        try {
+            systemDataLength = (short) dis.readUnsignedByte();
+            numberOfBeams = (short) dis.readUnsignedByte();
+            emissionsPadding2 = (int) dis.readUnsignedShort();
+            emitterSystem.unmarshal(dis);
+            location.unmarshal(dis);
+            for (int idx = 0; idx < numberOfBeams; idx++) {
+                ElectronicEmissisionBeamData anX = new ElectronicEmissisionBeamData();
+                anX.unmarshal(dis);
+                beamDataRecords.add(anX);
+            }
+        } // end try
+        catch (Exception e) {
+            System.out.println(e);
+        }
+    } // end of unmarshal method 
+    
+    /**
+     * Unpacks a Pdu from the underlying data.
+     *
+     * @throws java.nio.BufferUnderflowException if buff is too small
+     * @see java.nio.ByteBuffer
+     * @param buff The ByteBuffer at the position to begin reading
+     * @since ??
+     */
+    public void unmarshal(java.nio.ByteBuffer buff) {
+        systemDataLength = (short) (buff.get() & 0xFF);
+        numberOfBeams = (short) (buff.get() & 0xFF);
+        emissionsPadding2 = (int) (buff.getShort() & 0xFFFF);
+        emitterSystem.unmarshal(buff);
+        location.unmarshal(buff);
+        for (int idx = 0; idx < numberOfBeams; idx++) {
+            ElectronicEmissisionBeamData anX = new ElectronicEmissisionBeamData();
+            anX.unmarshal(buff);
+            beamDataRecords.add(anX);
+        }
+
+    } // end of unmarshal method 
+
+
+    /*
+  * The equals method doesn't always work--mostly it works only on classes that consist only of primitives. Be careful.
+     */
+    @Override
+    public boolean equals(Object obj) {
+
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null) {
+            return false;
+        }
+
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        return equalsImpl(obj);
+    }
+
+    /**
+     * Compare all fields that contribute to the state, ignoring transient and
+     * static fields, for <code>this</code> and the supplied object
+     *
+     * @param obj the object to compare to
+     * @return true if the objects are equal, false otherwise.
+     */
+    public boolean equalsImpl(Object obj) {
+        boolean ivarsEqual = true;
+
+        if (!(obj instanceof ElectronicEmissionSystemData)) {
+            return false;
+        }
+
+        final ElectronicEmissionSystemData rhs = (ElectronicEmissionSystemData) obj;
+
+        if (!(systemDataLength == rhs.systemDataLength)) {
+            ivarsEqual = false;
+        }
+        if (!(numberOfBeams == rhs.numberOfBeams)) {
+            ivarsEqual = false;
+        }
+        if (!(emissionsPadding2 == rhs.emissionsPadding2)) {
+            ivarsEqual = false;
+        }
+        if (!(emitterSystem.equals(rhs.emitterSystem))) {
+            ivarsEqual = false;
+        }
+        if (!(location.equals(rhs.location))) {
+            ivarsEqual = false;
+        }
+
+        for (int idx = 0; idx < beamDataRecords.size(); idx++) {
+            if (!(beamDataRecords.get(idx).equals(rhs.beamDataRecords.get(idx)))) {
+                ivarsEqual = false;
+            }
+        }
+
+        return ivarsEqual;
+    }
+} // end of class

--- a/src/main/java/edu/nps/moves/dis7/ElectronicEmissisionBeamData.java
+++ b/src/main/java/edu/nps/moves/dis7/ElectronicEmissisionBeamData.java
@@ -3,6 +3,8 @@ package edu.nps.moves.dis7;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -97,7 +99,7 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
      * included, this field shall be represented by a series of Track/Jam Data
      * records (see 6.2.90).
      */
-    protected TrackJamData trackJamData = new TrackJamData();
+    protected List<TrackJamData> trackJamData = new ArrayList<TrackJamData>();
 
     /**
      * Constructor
@@ -118,8 +120,9 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
         marshalSize = marshalSize + 1;  // highDensityTrackJam
         marshalSize = marshalSize + beamStatus.getMarshalledSize();  // beamStatus
         marshalSize = marshalSize + jammingTechnique.getMarshalledSize();  // jammingTechnique
-        if (numberOfTargets != 0) {
-            marshalSize = marshalSize + trackJamData.getMarshalledSize();  // trackJamData
+        for (int idx = 0; idx < trackJamData.size(); idx++) {
+            TrackJamData listElement = trackJamData.get(idx);
+            marshalSize = marshalSize + listElement.getMarshalledSize();
         }
 
         return marshalSize;
@@ -181,16 +184,21 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
         this.jammingTechnique = jammingTechnique;
     }
 
-    public TrackJamData getTrackJamData() {
+    public List<TrackJamData> getTrackJamData() {
         return trackJamData;
     }
 
-    public void setTrackJamData(TrackJamData trackJamData) {
+    public void setTrackJamData(List<TrackJamData> trackJamData) {
         this.trackJamData = trackJamData;
     }
 
     public int getBeamDataLength() {
         return beamDataLength;
+    }
+
+    short calculateBeamDataLength() {
+        //beam length = 13 + 2*track/jamTargets
+        return (short) ((2 * getTrackJamData().size()) + 13);
     }
 
     public void setBeamDataLength(short beamDataLength) {
@@ -225,9 +233,10 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
             dos.writeByte((byte) highDensityTrackJam);
             beamStatus.marshal(dos);
             jammingTechnique.marshal(dos);
-            if (numberOfTargets != 0) { //When the Number of Targets value is zero, this field shall be omitted
-                trackJamData.marshal(dos);
-            }
+            for (int idx = 0; idx < trackJamData.size(); idx++) {
+                TrackJamData aTrackJamTarget = (TrackJamData) trackJamData.get(idx);
+                aTrackJamTarget.marshal(dos);
+            } // end of list marshalling            
         } // end try
         catch (Exception e) {
             System.out.println(e);
@@ -254,9 +263,10 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
         buff.put((byte) highDensityTrackJam);
         beamStatus.marshal(buff);
         jammingTechnique.marshal(buff);
-        if (numberOfTargets != 0) { //When the Number of Targets value is zero, this field shall be omitted
-            trackJamData.marshal(buff);
-        }
+        for (int idx = 0; idx < trackJamData.size(); idx++) {
+            TrackJamData aTrackJamTarget = (TrackJamData) trackJamData.get(idx);
+            aTrackJamTarget.marshal(buff);
+        } // end of list marshalling
     } // end of marshal method
 
     public void unmarshal(DataInputStream dis) {
@@ -271,8 +281,10 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
             highDensityTrackJam = (short) dis.readUnsignedShort();
             beamStatus.unmarshal(dis);
             jammingTechnique.unmarshal(dis);
-            if (numberOfTargets != 0) { //When the Number of Targets value is zero, this field shall be omitted
-                trackJamData.unmarshal(dis);
+            for (int idx = 0; idx < numberOfTargets; idx++) {
+                TrackJamData anX = new TrackJamData();
+                anX.unmarshal(dis);
+                trackJamData.add(anX);
             }
 
         } // end try
@@ -300,8 +312,10 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
         highDensityTrackJam = (short) (buff.get() & 0xFF);
         beamStatus.unmarshal(buff);
         jammingTechnique.unmarshal(buff);
-        if (numberOfTargets != 0) { //When the Number of Targets value is zero, this field shall be omitted
-            trackJamData.unmarshal(buff);
+        for (int idx = 0; idx < numberOfTargets; idx++) {
+            TrackJamData anX = new TrackJamData();
+            anX.unmarshal(buff);
+            trackJamData.add(anX);
         }
     } // end of unmarshal method
 

--- a/src/main/java/edu/nps/moves/dis7/ElectronicEmissisionBeamData.java
+++ b/src/main/java/edu/nps/moves/dis7/ElectronicEmissisionBeamData.java
@@ -229,7 +229,7 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
             fundamentalParameterData.marshal(dos);
             beamData.marshal(dos);
             dos.writeByte((byte) beamFunction);
-            dos.writeByte((byte) numberOfTargets);
+            dos.writeByte((byte) trackJamData.size());
             dos.writeByte((byte) highDensityTrackJam);
             beamStatus.marshal(dos);
             jammingTechnique.marshal(dos);
@@ -259,7 +259,7 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
         fundamentalParameterData.marshal(buff);
         beamData.marshal(buff);
         buff.put((byte) beamFunction);
-        buff.put((byte) numberOfTargets);
+        buff.put((byte) trackJamData.size());
         buff.put((byte) highDensityTrackJam);
         beamStatus.marshal(buff);
         jammingTechnique.marshal(buff);
@@ -276,9 +276,9 @@ public class ElectronicEmissisionBeamData extends Object implements Serializable
             beamParameterIndex = dis.readUnsignedShort();
             fundamentalParameterData.unmarshal(dis);
             beamData.unmarshal(dis);
-            beamFunction = (short) dis.readUnsignedShort();
-            numberOfTargets = (short) dis.readUnsignedShort();
-            highDensityTrackJam = (short) dis.readUnsignedShort();
+            beamFunction = (short) dis.readByte();
+            numberOfTargets = (short) dis.readByte();
+            highDensityTrackJam = (short) dis.readByte();
             beamStatus.unmarshal(dis);
             jammingTechnique.unmarshal(dis);
             for (int idx = 0; idx < numberOfTargets; idx++) {

--- a/src/test/java/edu/nps/moves/dis7/ElectronicEmissionsPduTest.java
+++ b/src/test/java/edu/nps/moves/dis7/ElectronicEmissionsPduTest.java
@@ -58,7 +58,7 @@ public class ElectronicEmissionsPduTest
         assertEquals(51, pdu.getExerciseID());
         assertEquals(23, pdu.getPduType());
         assertEquals(6, pdu.getProtocolFamily());
-        assertEquals(100, pdu.getMarshalledSize());
+        assertEquals(104, pdu.getMarshalledSize());
         assertEquals(0, pdu.getPadding());
 
         ElectronicEmissionsPdu espdu = (ElectronicEmissionsPdu) pdu;
@@ -72,41 +72,41 @@ public class ElectronicEmissionsPduTest
         assertEquals(0, espdu.getEventID().getEventNumber());
 
         // Emission System
-        assertEquals(18, espdu.getSystemDataLength());
-        assertEquals(1, espdu.getNumberOfBeams());
+        assertEquals(18, espdu.getSystems().get(0).getSystemDataLength());
+        assertEquals(1, espdu.getSystems().get(0).getNumberOfBeams());
 
         // Emitter System
-        assertEquals(15660, espdu.getEmitterSystem().getEmitterName());
-        assertEquals(7, espdu.getEmitterSystem().getEmitterFunction());
-        assertEquals(1, espdu.getEmitterSystem().getEmitterIDNumber());
+        assertEquals(15660, espdu.getSystems().get(0).getEmitterSystem().getEmitterName());
+        assertEquals(7, espdu.getSystems().get(0).getEmitterSystem().getEmitterFunction());
+        assertEquals(1, espdu.getSystems().get(0).getEmitterSystem().getEmitterIDNumber());
 
         // Location
-        assertEquals(0.0, espdu.getLocation().getX(), 0.0001);
-        assertEquals(0.0, espdu.getLocation().getY(), 0.0001);
-        assertEquals(0.0, espdu.getLocation().getZ(), 0.0001);
+        assertEquals(0.0, espdu.getSystems().get(0).getLocation().getX(), 0.0001);
+        assertEquals(0.0, espdu.getSystems().get(0).getLocation().getY(), 0.0001);
+        assertEquals(0.0, espdu.getSystems().get(0).getLocation().getZ(), 0.0001);
 
         // Beam
-        assertEquals(13, espdu.getElectronicEmissionBeamData().getBeamDataLength());
-        assertEquals(1, espdu.getElectronicEmissionBeamData().getBeamNumber());
-        assertEquals(1, espdu.getElectronicEmissionBeamData().getBeamParameterIndex());
-        assertEquals(14000000000.0, espdu.getElectronicEmissionBeamData().getFundamentalParameterData().getFrequency(), 0.000001);
-        assertEquals(6000000000.0, espdu.getElectronicEmissionBeamData().getFundamentalParameterData().getFrequencyRange(), 0.000001);
-        assertEquals(55.0, espdu.getElectronicEmissionBeamData().getFundamentalParameterData().getEffectiveRadiatedPower(), 0.000001);
-        assertEquals(600.0, espdu.getElectronicEmissionBeamData().getFundamentalParameterData().getPulseRepetitionFrequency(), 0.000001);
-        assertEquals(3.0, espdu.getElectronicEmissionBeamData().getFundamentalParameterData().getPulseWidth(), 0.000001);
-        assertEquals(0, espdu.getElectronicEmissionBeamData().getBeamData().getBeamAzimuthCenter(), 0.000001);
-        assertEquals(0.698132, espdu.getElectronicEmissionBeamData().getBeamData().getBeamAzimuthSweep(), 0.000001);
-        assertEquals(0.436332, espdu.getElectronicEmissionBeamData().getBeamData().getBeamElevationCenter(), 0.000001);
-        assertEquals(0.436332, espdu.getElectronicEmissionBeamData().getBeamData().getBeamElevationSweep(), 0.000001);
-        assertEquals(90.4001, espdu.getElectronicEmissionBeamData().getBeamData().getBeamSweepSync(), 0.000001);
-        assertEquals(7, espdu.getElectronicEmissionBeamData().getBeamFunction());
-        assertEquals(0, espdu.getElectronicEmissionBeamData().getNumberOfTargets());
-        assertEquals(0, espdu.getElectronicEmissionBeamData().getHighDensityTrackJam());
-        assertEquals(0, espdu.getElectronicEmissionBeamData().getBeamStatus().getBeamState());
-        assertEquals(0, espdu.getElectronicEmissionBeamData().getJammingTechnique().getCategory());
-        assertEquals(0, espdu.getElectronicEmissionBeamData().getJammingTechnique().getKind());
-        assertEquals(0, espdu.getElectronicEmissionBeamData().getJammingTechnique().getSpecific());
-        assertEquals(0, espdu.getElectronicEmissionBeamData().getJammingTechnique().getCategory());
+        assertEquals(13, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamDataLength());
+        assertEquals(1, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamNumber());
+        assertEquals(1, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamParameterIndex());
+        assertEquals(14000000000.0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getFundamentalParameterData().getFrequency(), 0.000001);
+        assertEquals(6000000000.0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getFundamentalParameterData().getFrequencyRange(), 0.000001);
+        assertEquals(55.0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getFundamentalParameterData().getEffectiveRadiatedPower(), 0.000001);
+        assertEquals(600.0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getFundamentalParameterData().getPulseRepetitionFrequency(), 0.000001);
+        assertEquals(3.0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getFundamentalParameterData().getPulseWidth(), 0.000001);
+        assertEquals(0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamData().getBeamAzimuthCenter(), 0.000001);
+        assertEquals(0.698132, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamData().getBeamAzimuthSweep(), 0.000001);
+        assertEquals(0.436332, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamData().getBeamElevationCenter(), 0.000001);
+        assertEquals(0.436332, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamData().getBeamElevationSweep(), 0.000001);
+        assertEquals(90.4001, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamData().getBeamSweepSync(), 0.000001);
+        assertEquals(7, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamFunction());
+        assertEquals(0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getNumberOfTargets());
+        assertEquals(0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getHighDensityTrackJam());
+        assertEquals(0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getBeamStatus().getBeamState());
+        assertEquals(0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getJammingTechnique().getCategory());
+        assertEquals(0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getJammingTechnique().getKind());
+        assertEquals(0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getJammingTechnique().getSpecific());
+        assertEquals(0, espdu.getSystems().get(0).getBeamDataRecords().get(0).getJammingTechnique().getCategory());
 
 
     }


### PR DESCRIPTION
according to IEEE Std 1278.1™-2012 section 7.6.2 f , it shall be possible to have multiple emitter systems in a  Electromagnetic Emission PDU. The EE pdu has been changed to able to handle multiple emitter systems by introducing the ElectronicEmissionSystemData class(as in DIS 6).  
A fix has been made so that  it is possible to add more than one TrackJam to each beam, and fixed the unmarshall method so  beamFunction, numberOfTargets and highDensityTrackJam values  are read correct.