### PR TITLE
Fixed the issue of the call to leaveGroup using the wrong address.

### DIFF
--- a/src/main/java/edu/nps/moves/disutil/DisConnection.java
+++ b/src/main/java/edu/nps/moves/disutil/DisConnection.java
@@ -40,14 +40,14 @@ public class DisConnection implements Runnable {
     }
 
     public void terminate() {
-        socket.disconnect();
         try {
             if (socket instanceof MulticastSocket) {
-                ((MulticastSocket) socket).leaveGroup(socket.getInetAddress());
+                ((MulticastSocket) socket).leaveGroup(addr);
             }
         } catch (IOException ex) {
             Logger.getLogger(getClass().getName()).log(Level.SEVERE, null, ex);
         }
+        socket.close();
     }
 
     protected void handleMessage(Pdu pdu) {
@@ -85,4 +85,3 @@ public class DisConnection implements Runnable {
         terminate();
     }
 }
-

--- a/src/main/java/edu/nps/moves/examples/EspduSender.java
+++ b/src/main/java/edu/nps/moves/examples/EspduSender.java
@@ -123,5 +123,6 @@ public class EspduSender {
             System.out.println("Sleeping for heartbeat of " + DIS_HEARTBEAT_SECS + " seconds.");
             Thread.sleep(TimeUnit.SECONDS.toMillis(DIS_HEARTBEAT_SECS));
         }
+        con.terminate();
     }
 }


### PR DESCRIPTION
#183 Fixed the terminate method in DisConnection so that leaveGroup uses the correct address.

     Removed socket.disconnect() and replaced it by socket.close().

     Added con.terminate() at the end of the loop of EpduSender.java
